### PR TITLE
removed urls to non-existent documentation server

### DIFF
--- a/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzeinputsoutputs/src/main/java/com/ngc/seaside/jellyfish/cli/command/analyze/inputsoutputs/AnalyzeInputsOutputsCommand.java
+++ b/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzeinputsoutputs/src/main/java/com/ngc/seaside/jellyfish/cli/command/analyze/inputsoutputs/AnalyzeInputsOutputsCommand.java
@@ -31,8 +31,7 @@ import com.ngc.seaside.systemdescriptor.model.api.model.IModel;
 import com.ngc.seaside.systemdescriptor.service.source.api.ISourceLocation;
 
 /**
- * An analysis that checks for models which contain inputs but no outputs.  See
- * http://10.166.134.55/confluence/display/SEAS/Ch.+1+Avoid+components+that+have+inputs+but+no+outputs for details.
+ * An analysis that checks for models which contain inputs but no outputs. 
  */
 public class AnalyzeInputsOutputsCommand extends AbstractJellyfishAnalysisCommand {
 

--- a/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzeinputsoutputs/src/main/resources/docs/inputsWithNoOutputs.md
+++ b/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzeinputsoutputs/src/main/resources/docs/inputsWithNoOutputs.md
@@ -4,5 +4,3 @@ verified.  Minimally, a component should produce some type of output that indica
 allows the component to be tested as well as inspected.  This applies to both components that use pub/sub messaging an
 well as components that use request/response to exchange messages.
 
-See [Avoid components that have inputs but no outputs](http://10.166.134.55/confluence/display/SEAS/Ch.+1+Avoid+components+that+have+inputs+but+no+outputs) for more 
-information.

--- a/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzestyle/src/main/java/com/ngc/seaside/jellyfish/cli/command/analyzestyle/AnalyzeStyleCommand.java
+++ b/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzestyle/src/main/java/com/ngc/seaside/jellyfish/cli/command/analyzestyle/AnalyzeStyleCommand.java
@@ -59,8 +59,7 @@ import com.ngc.seaside.systemdescriptor.service.source.api.ISourceLocation;
 import com.ngc.seaside.systemdescriptor.service.source.api.ISourceLocatorService;
 
 /**
- * An analysis that checks that System Descriptor types follow standard naming conventions. See
- * http://10.166.134.55/confluence/display/SEAS/Ch.+1+Avoid+components+that+have+inputs+but+no+outputs for details.
+ * An analysis that checks that System Descriptor types follow standard naming conventions. 
  */
 public class AnalyzeStyleCommand extends AbstractJellyfishAnalysisCommand {
 

--- a/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzestyle/src/main/resources/docs/badProjectStructure.md
+++ b/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzestyle/src/main/resources/docs/badProjectStructure.md
@@ -9,5 +9,3 @@ The standard folder structure for a System Descriptor project includes the follo
     the aforementioned `ExampleModel` should be located at
     `<project-folder>/src/test/gherkin/com/example/test/ExampleModel.exampleScenario.feature`
 
-See [Follow the standard project structure and naming conventions](http://10.166.134.55/confluence/display/SEAS/Ch.+5+Follow+the+standard+project+structure+and+naming+conventions)
-for more information.

--- a/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzestyle/src/main/resources/docs/badStyle.md
+++ b/jellyfish-cli-analysis-commands/com.ngc.seaside.jellyfish.cli.command.analyzestyle/src/main/resources/docs/badStyle.md
@@ -11,5 +11,3 @@ The default conventions are:
 
 These default conventions may not be applicable if your team or program has established a different convention.
 
-See [Follow the standard project structure and naming conventions](http://10.166.134.55/confluence/display/SEAS/Ch.+5+Follow+the+standard+project+structure+and+naming+conventions)
-for more information.

--- a/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.createjellyfishgradleproject/src/main/template/templateContent/README.md
+++ b/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.createjellyfishgradleproject/src/main/template/templateContent/README.md
@@ -3,5 +3,3 @@
 ## Summary
 This repository consist of the ${projectName}.
 
-## More about extending and using of the JellyFish product line can be found on the CEACIDE wiki.
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.report.requirementsverification/src/test/resources/src/main/sd/com/ngc/seaside/testeval/McDonaldService.sd
+++ b/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.report.requirementsverification/src/test/resources/src/main/sd/com/ngc/seaside/testeval/McDonaldService.sd
@@ -37,7 +37,7 @@ model McDonaldService2 {
 	
 	scenario provideAverageService {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Engagement+Status+Calculation" }
+			"see": {"url": "http://localhost" }
 		}
 		when receiving fooStatus
 		then willPublish barStatus

--- a/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.report.requirementsverification/src/test/resources/src/main/sd/com/ngc/seaside/testeval/McDonaldService2.sd
+++ b/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.report.requirementsverification/src/test/resources/src/main/sd/com/ngc/seaside/testeval/McDonaldService2.sd
@@ -40,7 +40,7 @@ model McDonaldService {
 	
 	scenario provideAverageService {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Engagement+Status+Calculation" }
+			"see": {"url": "http://localhost" }
 		}
 		when receiving fooStatus
 		then willPublish barStatus

--- a/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.report.requirementsverification/src/test/resources/src/main/sd/com/ngc/seaside/testeval2/FooService.sd
+++ b/jellyfish-cli-commands/com.ngc.seaside.jellyfish.cli.command.report.requirementsverification/src/test/resources/src/main/sd/com/ngc/seaside/testeval2/FooService.sd
@@ -42,7 +42,7 @@ model FooService {
 	
 	scenario calculateFooness {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Engagement+Status+Calculation" }
+			"see": {"url": "http://localhost" }
 		}
 
 		when receiving fooStatus

--- a/jellyfish-cli/com.ngc.seaside.jellyfish.impl.provider/src/test/resources/invalid-grammar-project/src/main/resources/jellyfish.properties
+++ b/jellyfish-cli/com.ngc.seaside.jellyfish.impl.provider/src/test/resources/invalid-grammar-project/src/main/resources/jellyfish.properties
@@ -23,4 +23,4 @@
 
 project.name=threat-eval
 outputDir=../threat-eval
-requirementURLprefix=http://10.207.42.42:8080/display/SEAS/Threat+Evaluation+System+Requirements#ThreatEvaluationSystemRequirements-
+requirementURLprefix=http://localhost#ThreatEvaluationSystemRequirements-

--- a/jellyfish-cli/com.ngc.seaside.jellyfish.impl.provider/src/test/resources/valid-project/src/main/resources/jellyfish.properties
+++ b/jellyfish-cli/com.ngc.seaside.jellyfish.impl.provider/src/test/resources/valid-project/src/main/resources/jellyfish.properties
@@ -23,4 +23,4 @@
 
 project.name=threat-eval
 outputDir=../threat-eval
-requirementURLprefix=http://10.207.42.42:8080/display/SEAS/Threat+Evaluation+System+Requirements#ThreatEvaluationSystemRequirements-
+requirementURLprefix=http://localhost#ThreatEvaluationSystemRequirements-

--- a/jellyfish-cli/com.ngc.seaside.jellyfish.service.scenario.impl.scenarioservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/EngagementTrackPriorityService.sd
+++ b/jellyfish-cli/com.ngc.seaside.jellyfish.service.scenario.impl.scenarioservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/EngagementTrackPriorityService.sd
@@ -45,7 +45,7 @@ model EngagementTrackPriorityService {
 	
 	scenario calculateTrackPriority {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Engagement+Status+Calculation" } // TODO: need to find a way to stamp a version
+			"see": {"url": "http://localhost" } // TODO: need to find a way to stamp a version
 		}
 		when receiving trackEngagementStatus
 		then willCorrelate trackEngagementStatus.header.correlationEventId to trackPriority.header.correlationEventId 

--- a/jellyfish-cli/com.ngc.seaside.jellyfish.service.scenario.impl.scenarioservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/TrackPriorityService.sd
+++ b/jellyfish-cli/com.ngc.seaside.jellyfish.service.scenario.impl.scenarioservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/TrackPriorityService.sd
@@ -52,7 +52,7 @@ model TrackPriorityService {
 	
 	scenario calculateConsolidatedTrackPriority {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Consolidation" } // TODO: need to find a way to stamp a version
+			"see": {"url": "localhost" } // TODO: need to find a way to stamp a version
 		}
 		when receiving trackPriority
 		then willCorrelate trackPriority.header.correlationEventId to prioritizedSystemTracks.header.correlationEventId

--- a/jellyfish-cli/com.ngc.seaside.jellyfish.service.sequence.impl.sequenceservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/EngagementTrackPriorityService.sd
+++ b/jellyfish-cli/com.ngc.seaside.jellyfish.service.sequence.impl.sequenceservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/EngagementTrackPriorityService.sd
@@ -45,7 +45,7 @@ model EngagementTrackPriorityService {
 	
 	scenario calculateTrackPriority {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Engagement+Status+Calculation" } // TODO: need to find a way to stamp a version
+			"see": {"url": "http://localhost" } // TODO: need to find a way to stamp a version
 		}
 		when receiving trackEngagementStatus
 		then willCorrelate trackEngagementStatus.header.correlationEventId to trackPriority.header.correlationEventId 

--- a/jellyfish-cli/com.ngc.seaside.jellyfish.service.sequence.impl.sequenceservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/TrackPriorityService.sd
+++ b/jellyfish-cli/com.ngc.seaside.jellyfish.service.sequence.impl.sequenceservice/src/test/resources/src/main/sd/com/ngc/seaside/threateval/TrackPriorityService.sd
@@ -52,7 +52,7 @@ model TrackPriorityService {
 	
 	scenario calculateConsolidatedTrackPriority {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Consolidation" } // TODO: need to find a way to stamp a version
+			"see": {"url": "http://localhost" } // TODO: need to find a way to stamp a version
 		}
 		when receiving trackPriority
 		then willCorrelate trackPriority.header.correlationEventId to prioritizedSystemTracks.header.correlationEventId

--- a/jellyfish-examples/regressions/1/expectedOutput/com.ngc.seaside.threateval.classificationtrackpriorityservice/README.md
+++ b/jellyfish-examples/regressions/1/expectedOutput/com.ngc.seaside.threateval.classificationtrackpriorityservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.threateval.classificationtrackpriorityservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/10/expectedOutput/com.ngc.example.correlation.candyservice/README.md
+++ b/jellyfish-examples/regressions/10/expectedOutput/com.ngc.example.correlation.candyservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.example.correlation.candyservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/11/expectedOutput/com.model/README.md
+++ b/jellyfish-examples/regressions/11/expectedOutput/com.model/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.model.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/12/expectedOutput/com.ngc.seaside.threateval.trackpriorityservice/README.md
+++ b/jellyfish-examples/regressions/12/expectedOutput/com.ngc.seaside.threateval.trackpriorityservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.threateval.trackpriorityservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/13/expectedOutput/com.model2/README.md
+++ b/jellyfish-examples/regressions/13/expectedOutput/com.model2/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.model2.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/15/expectedOutput/com.ngc.seaside.threateval.threatevaluation/README.md
+++ b/jellyfish-examples/regressions/15/expectedOutput/com.ngc.seaside.threateval.threatevaluation/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.threateval.threatevaluation.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/2/expectedOutput/com.ngc.seaside.threateval.engagementtrackpriorityservice/README.md
+++ b/jellyfish-examples/regressions/2/expectedOutput/com.ngc.seaside.threateval.engagementtrackpriorityservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.threateval.engagementtrackpriorityservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/3/expectedOutput/com.ngc.seaside.threateval.defendedareatrackpriorityservice/README.md
+++ b/jellyfish-examples/regressions/3/expectedOutput/com.ngc.seaside.threateval.defendedareatrackpriorityservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.threateval.defendedareatrackpriorityservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/4/expectedOutput/com.ngc.seaside.threateval.trackpriorityservice/README.md
+++ b/jellyfish-examples/regressions/4/expectedOutput/com.ngc.seaside.threateval.trackpriorityservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.threateval.trackpriorityservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/5/expectedOutput/com.model/README.md
+++ b/jellyfish-examples/regressions/5/expectedOutput/com.model/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.model.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/6/expectedOutput/com.ngc.example.inhertance.databagsservice/README.md
+++ b/jellyfish-examples/regressions/6/expectedOutput/com.ngc.example.inhertance.databagsservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.example.inhertance.databagsservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/7/expectedOutput/com.ngc.seaside.jellyfish.examples.project1.model/README.md
+++ b/jellyfish-examples/regressions/7/expectedOutput/com.ngc.seaside.jellyfish.examples.project1.model/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.seaside.jellyfish.examples.project1.model.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/8/expectedOutput/com.test.model/README.md
+++ b/jellyfish-examples/regressions/8/expectedOutput/com.test.model/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.test.model.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/regressions/9/expectedOutput/com.ngc.example.correlation.peanutbutterservice/README.md
+++ b/jellyfish-examples/regressions/9/expectedOutput/com.ngc.example.correlation.peanutbutterservice/README.md
@@ -2,4 +2,3 @@
 
 This repository consist of the com.ngc.example.correlation.peanutbutterservice.
 
-http://10.207.42.43/confluence/display/SEAS/JellyFish+Implementation

--- a/jellyfish-examples/system-descriptor-projects/threat-eval-system-descriptor/src/main/resources/jellyfish.properties
+++ b/jellyfish-examples/system-descriptor-projects/threat-eval-system-descriptor/src/main/resources/jellyfish.properties
@@ -1,3 +1,3 @@
 project.name=threat-eval
 outputDir=../threat-eval
-requirements.urlPrefix=http://10.207.42.43/confluence/display/SEAS/Threat+Evaluation+System+Requirements#ThreatEvaluationSystemRequirements-
+requirements.urlPrefix=http://localhost#ThreatEvaluationSystemRequirements-

--- a/jellyfish-examples/system-descriptor-projects/threat-eval-system-descriptor/src/main/sd/com/ngc/seaside/threateval/EngagementTrackPriorityService.sd
+++ b/jellyfish-examples/system-descriptor-projects/threat-eval-system-descriptor/src/main/sd/com/ngc/seaside/threateval/EngagementTrackPriorityService.sd
@@ -45,7 +45,7 @@ model EngagementTrackPriorityService {
 	
 	scenario calculateTrackPriority {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Engagement+Status+Calculation" } // TODO: need to find a way to stamp a version
+			"see": {"url": "http://localhost" } // TODO: need to find a way to stamp a version
 		}
 		when receiving trackEngagementStatus
 		then willCorrelate trackEngagementStatus.header.correlationEventId to trackPriority.header.correlationEventId 

--- a/jellyfish-examples/system-descriptor-projects/threat-eval-system-descriptor/src/main/sd/com/ngc/seaside/threateval/TrackPriorityService.sd
+++ b/jellyfish-examples/system-descriptor-projects/threat-eval-system-descriptor/src/main/sd/com/ngc/seaside/threateval/TrackPriorityService.sd
@@ -52,7 +52,7 @@ model TrackPriorityService {
 	
 	scenario calculateConsolidatedTrackPriority {
 		metadata {
-			"see": {"url": "http://10.207.42.43/confluence/display/SEAS/Track+Priority+Consolidation" } // TODO: need to find a way to stamp a version
+			"see": {"url": "http://localhost" } // TODO: need to find a way to stamp a version
 		}
 		when receiving trackPriority
 		then willCorrelate trackPriority.header.correlationEventId to prioritizedSystemTracks.header.correlationEventId


### PR DESCRIPTION
There were references to a documentation server that was removed years ago but never cleaned up in the code.  Just removed or replaced with localhost for now.  Unfortunately the associated documentation has been lost.